### PR TITLE
Fix model

### DIFF
--- a/asyncord/gateway/events/interactions.py
+++ b/asyncord/gateway/events/interactions.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, RootModel
 
 from asyncord.client.models.channel_data import ChannelType
 from asyncord.client.models.commands import AppCommandOptionType, ApplicationCommandType
-from asyncord.client.models.components import ActionRow, ComponentType, SelectMenuOption
+from asyncord.client.models.components import ActionRow, ComponentType
 from asyncord.client.models.members import Member
 from asyncord.client.models.messages import Attachment, Embed, InteractionType, MessageFlags, MessageType
 from asyncord.client.models.permissions import PermissionFlag
@@ -326,7 +326,7 @@ class MessageComponentInteractionData(BaseModel):
     component_type: ComponentType
     """Type of the component."""
 
-    values: list[SelectMenuOption] | None = None
+    values: list[str] | None = None
     """Values the user selected."""
 
 


### PR DESCRIPTION
Model MessageComponentInteractionData has an incorrect [field](https://github.com/suharnikov/asyncord/blob/31efdbfb5bbdbc21ef0bf5f91f79aec7082d5d31/asyncord/gateway/events/interactions.py#L329C13-L329C28)

It's actually a list of SelectOption values chosen by user from the list menu, not SelectOption whole object. 
So is just a list of strings. 

[Reference](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-message-component-data-structure)